### PR TITLE
Switch from deprecated X.max(idx) to idx=X.index_max()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,6 +13,8 @@ Depends: R (>= 2.10.0), stats, Rtsne, umap
 Imports: Rcpp (>= 0.12.4), Rnanoflann, methods, Matrix
 LinkingTo: Rcpp, RcppArmadillo, Rnanoflann, Matrix
 Suggests: rgl, knitr, rmarkdown
+URL: https://github.com/tkcaccia/KODAMA
+BugReports: https://github.com/tkcaccia/KODAMA/issues
 VignetteBuilder: knitr
 SuggestsNote: No suggestions
 License: GPL (>= 2)

--- a/src/prova.cpp
+++ b/src/prova.cpp
@@ -461,8 +461,8 @@ arma::ivec PLSDACV_simpls(arma::mat x,arma::ivec cl,arma::ivec constrain,int k) 
   for (int i=0; i<mm2; i++) {
     ww=i;
     arma::mat v22=Ytest.rows(ww);
-    arma::uword index;                                                                                                                                                                                                                                                                                                                
-    min_val = v22.max(index);
+    arma::uword index = v22.index_max();
+    min_val = v22(index);
     pp(i)=index+1;
   }
   return pp;
@@ -524,8 +524,8 @@ arma::ivec PLSDACV_fastpls(arma::mat x,arma::ivec cl,arma::ivec constrain,int k)
   for (int i=0; i<mm2; i++) {
     ww=i;
     arma::mat v22=Ytest.rows(ww);
-    arma::uword index;                                                                                                                                                                                                                                                                                                                
-    min_val = v22.max(index);
+    arma::uword index = v22.index_max();                                                                                              
+    min_val = v22(index);
     pp(i)=index+1;
   }
   return pp;
@@ -672,8 +672,7 @@ List corecpp(arma::mat x,
       for (int i=0; i<mm2; i++) {
         ww=i;
         arma::mat v22=projmat.rows(ww);
-        arma::uword index;                                                                                                                                                                                                                                                                                                                
-        min_val = v22.max(index);
+        arma::uword index = v22.index_max();                                                                                                                                                                              min_val = v22(index);
         pp(i)=index+1;
       }
     }
@@ -689,8 +688,8 @@ List corecpp(arma::mat x,
       for (int i=0; i<mm2; i++) {
         ww=i;
         arma::mat v22=projmat.rows(ww);
-        arma::uword index;                                                                                                                                                                                                                                                                                                                
-        min_val = v22.max(index);
+        arma::uword index=v22.index_max();                                                                                              
+        min_val = v22(index);
         pp(i)=index+1;
       }
     }


### PR DESCRIPTION
Armadillo 15.0.* now makes C++14 the minimum compilation standard, which also means I can no-longer add the suppression of deprecation warnings (which used a macro before and now use a C++14 or later attribute). For most packages, adapting to it can be very simple, and yours is one of them -- in fact it is just four statements. In the patch below we simply update this as now required by Armadillo 15.0.x.  (I also took the liberty of adding URL and BugReports fields to DESCRIPTION; they make finding underlying repositories such as this much easier :wink: but feel free to ignore / revert that part).

Please see issues [#475](https://github.com/RcppCore/RcppArmadillo/issues/475) and below at the RcppArmadillo GitHub repo for context, and notably [#491](https://github.com/RcppCore/RcppArmadillo/issues/491) for this second wave of PRs and patches (following one for moving away from C++11, something your package does not need). It would be terrific if you could make an upload to CRAN 'soon' to remove the deprecation warning. Please do not hesitate to reach out if I can assist in any way or clarify matters -- see also [this blog post from yesterday](http://dirk.eddelbuettel.com/blog/2025/10/10#rcpparmadillo_15_transition_office_hours) and the [corresponding email to the r-package-devel list](https://stat.ethz.ch/pipermail/r-package-devel/2025q4/012051.html) -- I can offer help in informal 'office hours' over zoom or google meet.